### PR TITLE
 Fix writing of compressed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,21 @@ Linux distributions install 64-bit libraries into lib64 and
 
 #### 2.2.3 Visual Studio
 Visual Studio solutions are provided as [matio_vs2008.sln](visual_studio/matio_vs2008.sln)
-for VS2008 and as [matio.sln](visual_studio/matio.sln) for VS2010.
+for VS2008 and as [matio.sln](visual_studio/matio.sln) for VS2010 (and newer).
 The solutions are set up to build a DLL of the matio library
 (libmatio.dll) and matdump tool and assume HDF5 is
 available in the directory specified by the HDF5_DIR environment
-variable. The VS2008 build was tested with the [HDF5 1.8.12 Visual Studio pre-built
+variable. It is assumed that the **shared** libraries of HDF5 (and zlib) are available. If the **static**
+libraries of HDF5 (and zlib) are installed/built the macro `H5_BUILT_AS_STATIC_LIB` needs to be defined
+(instead of `H5_BUILT_AS_DYNAMIC_LIB`).
+* The VS2008 solution was tested with Visual Studio 2008 and the [HDF5 1.8.12 Visual Studio pre-built
 Windows binaries](https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.12/bin/windows/) (vs9shared)
-including zlib. The VS2010 build was tested with the [HDF5 1.8.13 Visual Studio pre-built
+including zlib.
+* The VS2010 solution was tested with Visual Studio 2010 and the [HDF5 1.8.13 Visual Studio pre-built
 Windows binaries](https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/bin/windows/) (VS2010-shared)
+including zlib.
+* The updated VS2010 solution was tested with Visual Studio 2015 and the [HDF5 1.8.16 Visual Studio pre-built
+Windows binaries](https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.16/bin/windows/extra/) (vs2015-shared)
 including zlib.
 
 #### 2.2.4 Testsuite

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -649,21 +649,23 @@ WriteCompressedCharData(mat_t *mat,z_stream *z,void *data,int N,
         case MAT_T_UINT16:
         {
             data_size = 2;
-            data_tag[0]  = MAT_T_UINT16;
-            data_tag[1]  = N*data_size;
-            z->next_in   = ZLIB_BYTE_PTR(data_tag);
-            z->avail_in  = 8;
-            z->next_out  = buf;
-            z->avail_out = buf_size;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            data_tag[0] = MAT_T_UINT16;
+            data_tag[1] = N*data_size;
+            z->next_in  = ZLIB_BYTE_PTR(data_tag);
+            z->avail_in = 8;
+            do {
+                z->next_out  = buf;
+                z->avail_out = buf_size;
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
 
             /* exit early if this is a empty data */
             if ( NULL == data || N < 1 )
                 break;
 
-            z->next_in   = data;
-            z->avail_in  = data_size*N;
+            z->next_in  = data;
+            z->avail_in = data_size*N;
             do {
                 z->next_out  = buf;
                 z->avail_out = buf_size;
@@ -672,12 +674,14 @@ WriteCompressedCharData(mat_t *mat,z_stream *z,void *data,int N,
             } while ( z->avail_out == 0 );
             /* Add/Compress padding to pad to 8-byte boundary */
             if ( N*data_size % 8 ) {
-                z->next_in   = pad;
-                z->avail_in  = 8 - (N*data_size % 8);
-                z->next_out  = buf;
-                z->avail_out = buf_size;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                z->next_in  = pad;
+                z->avail_in = 8 - (N*data_size % 8);
+                do {
+                    z->next_out  = buf;
+                    z->avail_out = buf_size;
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
             }
             break;
         }
@@ -688,62 +692,70 @@ WriteCompressedCharData(mat_t *mat,z_stream *z,void *data,int N,
             mat_uint16_t c;
 
             /* Matlab can't read MAT_C_CHAR as uint8, needs uint16 */
-            data_size    = 2;
-            data_tag[0]  = MAT_T_UINT16;
-            data_tag[1]  = N*data_size;
-            z->next_in   = ZLIB_BYTE_PTR(data_tag);
-            z->avail_in  = 8;
-            z->next_out  = buf;
-            z->avail_out = buf_size;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            data_size   = 2;
+            data_tag[0] = MAT_T_UINT16;
+            data_tag[1] = N*data_size;
+            z->next_in  = ZLIB_BYTE_PTR(data_tag);
+            z->avail_in = 8;
+            do {
+                z->next_out  = buf;
+                z->avail_out = buf_size;
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
 
             /* exit early if this is a empty data */
             if ( NULL == data || N < 1 )
                 break;
 
-            z->next_in   = data;
-            z->avail_in  = data_size*N;
+            z->next_in  = data;
+            z->avail_in = data_size*N;
             ptr = data;
             for ( i = 0; i < N; i++ ) {
                 c = (mat_uint16_t)*(char *)ptr;
-                z->next_in   = ZLIB_BYTE_PTR(&c);
-                z->avail_in  = 2;
-                z->next_out  = buf;
-                z->avail_out = buf_size;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                z->next_in  = ZLIB_BYTE_PTR(&c);
+                z->avail_in = 2;
+                do {
+                    z->next_out  = buf;
+                    z->avail_out = buf_size;
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
                 ptr++;
             }
             /* Add/Compress padding to pad to 8-byte boundary */
             if ( N*data_size % 8 ) {
-                z->next_in   = pad;
-                z->avail_in  = 8 - (N*data_size % 8);
-                z->next_out  = buf;
-                z->avail_out = buf_size;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                z->next_in  = pad;
+                z->avail_in = 8 - (N*data_size % 8);
+                do {
+                    z->next_out  = buf;
+                    z->avail_out = buf_size;
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
             }
             break;
         }
         case MAT_T_UTF8:
         {
             data_size = 1;
-            data_tag[0]  = MAT_T_UTF8;
-            data_tag[1]  = N*data_size;
-            z->next_in   = ZLIB_BYTE_PTR(data_tag);
-            z->avail_in  = 8;
-            z->next_out  = buf;
-            z->avail_out = buf_size;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            data_tag[0] = MAT_T_UTF8;
+            data_tag[1] = N*data_size;
+            z->next_in  = ZLIB_BYTE_PTR(data_tag);
+            z->avail_in = 8;
+            do {
+                z->next_out  = buf;
+                z->avail_out = buf_size;
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
 
             /* exit early if this is a empty data */
             if ( NULL == data || N < 1 )
                 break;
 
-            z->next_in   = data;
-            z->avail_in  = data_size*N;
+            z->next_in  = data;
+            z->avail_in = data_size*N;
             do {
                 z->next_out  = buf;
                 z->avail_out = buf_size;
@@ -752,12 +764,14 @@ WriteCompressedCharData(mat_t *mat,z_stream *z,void *data,int N,
             } while ( z->avail_out == 0 );
             /* Add/Compress padding to pad to 8-byte boundary */
             if ( N*data_size % 8 ) {
-                z->next_in   = pad;
-                z->avail_in  = 8 - (N*data_size % 8);
-                z->next_out  = buf;
-                z->avail_out = buf_size;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                z->next_in  = pad;
+                z->avail_in = 8 - (N*data_size % 8);
+                do {
+                    z->next_out  = buf;
+                    z->avail_out = buf_size;
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
             }
             break;
         }
@@ -767,14 +781,16 @@ WriteCompressedCharData(mat_t *mat,z_stream *z,void *data,int N,
              * a data tag
              */
             data_size = 2;
-            data_tag[0]  = MAT_T_UINT16;
-            data_tag[1]  = N*data_size;
-            z->next_in   = ZLIB_BYTE_PTR(data_tag);
-            z->avail_in  = 8;
-            z->next_out  = buf;
-            z->avail_out = buf_size;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            data_tag[0] = MAT_T_UINT16;
+            data_tag[1] = N*data_size;
+            z->next_in  = ZLIB_BYTE_PTR(data_tag);
+            z->avail_in = 8;
+            do {
+                z->next_out  = buf;
+                z->avail_out = buf_size;
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
         }
         default:
             break;
@@ -1013,19 +1029,23 @@ WriteCompressedEmptyData(mat_t *mat,z_stream *z,int N,
             nBytes = N*data_size;
             uncomp_buf[0] = data_type;
             uncomp_buf[1] = 0;
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            z->avail_out = 32*sizeof(*comp_buf);
-            z->avail_in  = 8;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,32*sizeof(*comp_buf)-z->avail_out,mat->fp);
-            for ( i = 0; i < N; i++ ) {
+            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            z->avail_in = 8;
+            do {
                 z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->next_in   = ZLIB_BYTE_PTR(data_uncomp_buf);
                 z->avail_out = 32*sizeof(*comp_buf);
-                z->avail_in  = 8;
                 err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,32*sizeof(*comp_buf)-z->avail_out,1,mat->fp);
+                byteswritten += fwrite(comp_buf,1,32*sizeof(*comp_buf)-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
+            for ( i = 0; i < N; i++ ) {
+                z->next_in  = ZLIB_BYTE_PTR(data_uncomp_buf);
+                z->avail_in = 8;
+                do {
+                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = 32*sizeof(*comp_buf);
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf,32*sizeof(*comp_buf)-z->avail_out,1,mat->fp);
+                } while ( z->avail_out == 0 );
             }
             break;
         }
@@ -1556,21 +1576,23 @@ WriteCompressedData(mat_t *mat,z_stream *z,void *data,int N,
 
     data_size = Mat_SizeOf(data_type);
 
-    data_tag[0]  = data_type;
-    data_tag[1]  = data_size*N;
-    z->next_in   = ZLIB_BYTE_PTR(data_tag);
-    z->avail_in  = 8;
-    z->next_out  = buf;
-    z->avail_out = buf_size;
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+    data_tag[0] = data_type;
+    data_tag[1] = data_size*N;
+    z->next_in  = ZLIB_BYTE_PTR(data_tag);
+    z->avail_in = 8;
+    do {
+        z->next_out  = buf;
+        z->avail_out = buf_size;
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+    } while ( z->avail_out == 0 );
 
     /* exit early if this is a empty data */
     if ( NULL == data || N < 1 )
         return byteswritten;
 
-    z->next_in   = data;
-    z->avail_in  = N*data_size;
+    z->next_in  = data;
+    z->avail_in = N*data_size;
     do {
         z->next_out  = buf;
         z->avail_out = buf_size;
@@ -1579,12 +1601,14 @@ WriteCompressedData(mat_t *mat,z_stream *z,void *data,int N,
     } while ( z->avail_out == 0 );
     /* Add/Compress padding to pad to 8-byte boundary */
     if ( N*data_size % 8 ) {
-        z->next_in   = pad;
-        z->avail_in  = 8 - (N*data_size % 8);
-        z->next_out  = buf;
-        z->avail_out = buf_size;
-        err = deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+        z->next_in  = pad;
+        z->avail_in = 8 - (N*data_size % 8);
+        do {
+            z->next_out  = buf;
+            z->avail_out = buf_size;
+            err = deflate(z,Z_NO_FLUSH);
+            byteswritten += fwrite(buf,1,buf_size-z->avail_out,mat->fp);
+        } while ( z->avail_out == 0 );
     }
     nBytes = byteswritten;
     return nBytes;
@@ -2204,7 +2228,7 @@ ReadNextFunctionHandle(mat_t *mat, matvar_t *matvar)
         matvar->data_size = sizeof(matvar_t *);
         matvar->nbytes    = nfunctions*matvar->data_size;
         functions = matvar->data;
-        for ( i = 0 ; i < nfunctions; i++ )
+        for ( i = 0; i < nfunctions; i++ )
             functions[i] = Mat_VarReadNextInfo(mat);
     } else {
         bytesread = 0;
@@ -2627,13 +2651,15 @@ WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,z_stream *z)
 
     uncomp_buf[0] = MAT_T_MATRIX;
     uncomp_buf[1] = (int)GetCellArrayFieldBufSize(matvar);
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size*sizeof(*comp_buf);
-    z->avail_in  = 8;
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-        mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = 8;
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size*sizeof(*comp_buf);
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
+            mat->fp);
+    } while ( z->avail_out == 0 );
     uncomp_buf[0] = array_flags_type;
     uncomp_buf[1] = array_flags_size;
     uncomp_buf[2] = array_flags;
@@ -2653,23 +2679,27 @@ WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,z_stream *z)
         i++;
     }
 
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size*sizeof(*comp_buf);
-    z->avail_in  = (6+i)*sizeof(*uncomp_buf);
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-        mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = (6+i)*sizeof(*uncomp_buf);
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size*sizeof(*comp_buf);
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
+            mat->fp);
+    } while ( z->avail_out == 0 );
     /* Name of variable */
     uncomp_buf[0] = array_name_type;
     uncomp_buf[1] = 0;
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size*sizeof(*comp_buf);
-    z->avail_in  = 8;
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-        mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = 8;
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size*sizeof(*comp_buf);
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
+            mat->fp);
+    } while ( z->avail_out == 0 );
 
     matvar->internal->datapos = ftell(mat->fp);
     switch ( matvar->class_type ) {
@@ -2739,13 +2769,15 @@ WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,z_stream *z)
                 uncomp_buf[1] = 1;
                 uncomp_buf[2] = array_name_type;
                 uncomp_buf[3] = 0;
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                z->avail_in  = 16;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,buf_size*
-                    sizeof(*comp_buf)-z->avail_out,mat->fp);
+                z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+                z->avail_in = 16;
+                do {
+                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = buf_size*sizeof(*comp_buf);
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf,1,buf_size*
+                        sizeof(*comp_buf)-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
                 break;
             }
 
@@ -2766,24 +2798,28 @@ WriteCompressedCellArrayField(mat_t *mat,matvar_t *matvar,z_stream *z)
             uncomp_buf[3] = nfields*fieldname_size;
 
             padzero = calloc(fieldname_size,1);
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            z->avail_out = buf_size*sizeof(*comp_buf);
-            z->avail_in  = 16;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,
+            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            z->avail_in = 16;
+            do {
+                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size*sizeof(*comp_buf);
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,
                     buf_size*sizeof(*comp_buf)-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
             for ( i = 0; i < nfields; i++ ) {
                 memset(padzero,'\0',fieldname_size);
                 memcpy(padzero,matvar->internal->fieldnames[i],
-                       strlen(matvar->internal->fieldnames[i]));
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->next_in   = ZLIB_BYTE_PTR(padzero);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                z->avail_in  = fieldname_size;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,
+                    strlen(matvar->internal->fieldnames[i]));
+                z->next_in  = ZLIB_BYTE_PTR(padzero);
+                z->avail_in = fieldname_size;
+                do {
+                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = buf_size*sizeof(*comp_buf);
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf,1,
                         buf_size*sizeof(*comp_buf)-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
             }
             free(padzero);
             for ( i = 0; i < nmemb*nfields; i++ )
@@ -3078,13 +3114,15 @@ WriteCompressedStructField(mat_t *mat,matvar_t *matvar,z_stream *z)
 
     uncomp_buf[0] = MAT_T_MATRIX;
     uncomp_buf[1] = (int)GetStructFieldBufSize(matvar);
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size*sizeof(*comp_buf);
-    z->avail_in  = 8;
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-        mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = 8;
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size*sizeof(*comp_buf);
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
+            mat->fp);
+    } while ( z->avail_out == 0 );
     uncomp_buf[0] = array_flags_type;
     uncomp_buf[1] = array_flags_size;
     uncomp_buf[2] = array_flags;
@@ -3104,23 +3142,27 @@ WriteCompressedStructField(mat_t *mat,matvar_t *matvar,z_stream *z)
         i++;
     }
 
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size*sizeof(*comp_buf);
-    z->avail_in  = (6+i)*sizeof(*uncomp_buf);
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-        mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = (6+i)*sizeof(*uncomp_buf);
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size*sizeof(*comp_buf);
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
+            mat->fp);
+    } while ( z->avail_out == 0 );
     /* Name of variable */
     uncomp_buf[0] = array_name_type;
     uncomp_buf[1] = 0;
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size*sizeof(*comp_buf);
-    z->avail_in  = 8;
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
-        mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = 8;
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size*sizeof(*comp_buf);
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-z->avail_out,
+            mat->fp);
+    } while ( z->avail_out == 0 );
 
     matvar->internal->datapos = ftell(mat->fp);
     switch ( matvar->class_type ) {
@@ -3190,13 +3232,15 @@ WriteCompressedStructField(mat_t *mat,matvar_t *matvar,z_stream *z)
                 uncomp_buf[1] = 1;
                 uncomp_buf[2] = array_name_type;
                 uncomp_buf[3] = 0;
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                z->avail_in  = 16;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,buf_size*
-                    sizeof(*comp_buf)-z->avail_out,mat->fp);
+                z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+                z->avail_in = 16;
+                do {
+                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = buf_size*sizeof(*comp_buf);
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf,1,buf_size*
+                        sizeof(*comp_buf)-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
                 break;
             }
             for ( i = 0; i < nfields; i++ ) {
@@ -3214,24 +3258,28 @@ WriteCompressedStructField(mat_t *mat,matvar_t *matvar,z_stream *z)
             uncomp_buf[3] = nfields*fieldname_size;
 
             padzero = calloc(fieldname_size,1);
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            z->avail_out = buf_size*sizeof(*comp_buf);
-            z->avail_in  = 16;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,
+            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            z->avail_in = 16;
+            do {
+                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size*sizeof(*comp_buf);
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,
                     buf_size*sizeof(*comp_buf)-z->avail_out,mat->fp);
+            } while ( z->avail_out == 0 );
             for ( i = 0; i < nfields; i++ ) {
                 size_t len = strlen(matvar->internal->fieldnames[i]);
                 memset(padzero,'\0',fieldname_size);
                 memcpy(padzero,matvar->internal->fieldnames[i],len);
-                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                z->next_in   = ZLIB_BYTE_PTR(padzero);
-                z->avail_out = buf_size*sizeof(*comp_buf);
-                z->avail_in  = fieldname_size;
-                err = deflate(z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,
+                z->next_in  = ZLIB_BYTE_PTR(padzero);
+                z->avail_in = fieldname_size;
+                do {
+                    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                    z->avail_out = buf_size*sizeof(*comp_buf);
+                    err = deflate(z,Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf,1,
                         buf_size*sizeof(*comp_buf)-z->avail_out,mat->fp);
+                } while ( z->avail_out == 0 );
             }
             free(padzero);
             for ( i = 0; i < nmemb*nfields; i++ )
@@ -3372,12 +3420,14 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
 
     uncomp_buf[0] = MAT_T_MATRIX;
     uncomp_buf[1] = (int)GetEmptyMatrixMaxBufSize(name,rank);
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size_bytes;
-    z->avail_in  = 8;
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = 8;
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size_bytes;
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,mat->fp);
+    } while ( z->avail_out == 0 );
     uncomp_buf[0] = array_flags_type;
     uncomp_buf[1] = array_flags_size;
     uncomp_buf[2] = array_flags;
@@ -3397,22 +3447,26 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
         i++;
     }
 
-    z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-    z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-    z->avail_out = buf_size_bytes;
-    z->avail_in  = (6+i)*sizeof(*uncomp_buf);
-    err = deflate(z,Z_NO_FLUSH);
-    byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,mat->fp);
+    z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+    z->avail_in = (6+i)*sizeof(*uncomp_buf);
+    do {
+        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+        z->avail_out = buf_size_bytes;
+        err = deflate(z,Z_NO_FLUSH);
+        byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,mat->fp);
+    } while ( z->avail_out == 0 );
     /* Name of variable */
     if ( NULL == name ) {
         uncomp_buf[0] = array_name_type;
         uncomp_buf[1] = 0;
-        z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-        z->avail_out = buf_size_bytes;
-        z->avail_in  = 8;
-        err = deflate(z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,mat->fp);
+        z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+        z->avail_in = 8;
+        do {
+            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+            z->avail_out = buf_size_bytes;
+            err = deflate(z,Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,mat->fp);
+        } while ( z->avail_out == 0 );
     } else {
         if ( strlen(name) <= 4 ) {
             mat_int16_t array_name_len = (mat_int16_t)strlen(name);
@@ -3424,13 +3478,15 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
             if ( array_name_len % 4 )
                 array_name_len += 4-(array_name_len % 4);
 
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            z->avail_out = buf_size_bytes;
-            z->avail_in  = 8;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,
-                                   mat->fp);
+            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            z->avail_in = 8;
+            do {
+                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size_bytes;
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,
+                    mat->fp);
+            } while ( z->avail_out == 0 );
         } else {
             mat_int32_t array_name_len = (mat_int32_t)strlen(name);
             mat_int32_t array_name_type = MAT_T_INT8;
@@ -3441,13 +3497,15 @@ Mat_WriteCompressedEmptyVariable5(mat_t *mat,const char *name,int rank,
             memcpy(uncomp_buf+2,name,array_name_len);
             if ( array_name_len % 8 )
                 array_name_len += 8-(array_name_len % 8);
-            z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            z->avail_out = buf_size_bytes;
-            z->avail_in  = 8+array_name_len;
-            err = deflate(z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,
-                                   mat->fp);
+            z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            z->avail_in = 8+array_name_len;
+            do {
+                z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                z->avail_out = buf_size_bytes;
+                err = deflate(z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,buf_size_bytes-z->avail_out,
+                    mat->fp);
+            } while ( z->avail_out == 0 );
         }
     }
 
@@ -5470,13 +5528,15 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
 
         uncomp_buf[0] = MAT_T_MATRIX;
         uncomp_buf[1] = (int)GetMatrixMaxBufSize(matvar);
-        matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        matvar->internal->z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-        matvar->internal->z->avail_in  = 8;
-        err = deflate(matvar->internal->z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,
-            buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+        matvar->internal->z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+        matvar->internal->z->avail_in = 8;
+        do {
+            matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+            err = deflate(matvar->internal->z,Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf,1,
+                buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+        } while ( matvar->internal->z->avail_out == 0 );
         uncomp_buf[0] = array_flags_type;
         uncomp_buf[1] = array_flags_size;
         uncomp_buf[2] = array_flags;
@@ -5496,13 +5556,15 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             i++;
         }
 
-        matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        matvar->internal->z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-        matvar->internal->z->avail_in  = (6+i)*sizeof(*uncomp_buf);
-        err = deflate(matvar->internal->z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,
+        matvar->internal->z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+        matvar->internal->z->avail_in = (6+i)*sizeof(*uncomp_buf);
+        do {
+            matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+            err = deflate(matvar->internal->z,Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf,1,
                 buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+        } while ( matvar->internal->z->avail_out == 0 );
         /* Name of variable */
         if ( strlen(matvar->name) <= 4 ) {
             mat_int16_t array_name_len = (mat_int16_t)strlen(matvar->name);
@@ -5514,13 +5576,15 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             if ( array_name_len % 4 )
                 array_name_len += 4-(array_name_len % 4);
 
-            matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            matvar->internal->z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-            matvar->internal->z->avail_in  = 8;
-            err = deflate(matvar->internal->z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,
+            matvar->internal->z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            matvar->internal->z->avail_in = 8;
+            do {
+                matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,
                     buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+            } while ( matvar->internal->z->avail_out == 0 );
         } else {
             mat_int32_t array_name_len = (mat_int32_t)strlen(matvar->name);
             mat_int32_t array_name_type = MAT_T_INT8;
@@ -5531,13 +5595,15 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             memcpy(uncomp_buf+2,matvar->name,array_name_len);
             if ( array_name_len % 8 )
                 array_name_len += 8-(array_name_len % 8);
-            matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-            matvar->internal->z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-            matvar->internal->z->avail_in  = 8+array_name_len;
-            err = deflate(matvar->internal->z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,
+            matvar->internal->z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+            matvar->internal->z->avail_in = 8+array_name_len;
+            do {
+                matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,
                     buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+            } while ( matvar->internal->z->avail_out == 0 );
         }
         matvar->internal->datapos = ftell(mat->fp);
         switch ( matvar->class_type ) {
@@ -5606,13 +5672,15 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
                     uncomp_buf[1] = 1;
                     uncomp_buf[2] = array_name_type;
                     uncomp_buf[3] = 0;
-                    matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                    matvar->internal->z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-                    matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-                    matvar->internal->z->avail_in  = 16;
-                    err = deflate(matvar->internal->z,Z_NO_FLUSH);
-                    byteswritten += fwrite(comp_buf,1,buf_size*
-                        sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+                    matvar->internal->z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+                    matvar->internal->z->avail_in = 16;
+                    do {
+                        matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                        err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                        byteswritten += fwrite(comp_buf,1,buf_size*
+                            sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+                    } while ( matvar->internal->z->avail_out == 0 );
                     break;
                 }
                 nfields = matvar->internal->num_fields;
@@ -5631,25 +5699,29 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
                 uncomp_buf[3] = nfields*fieldname_size;
 
                 padzero = calloc(fieldname_size,1);
-                matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                matvar->internal->z->next_in   = ZLIB_BYTE_PTR(uncomp_buf);
-                matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-                matvar->internal->z->avail_in  = 16;
-                err = deflate(matvar->internal->z,Z_NO_FLUSH);
-                byteswritten += fwrite(comp_buf,1,
+                matvar->internal->z->next_in  = ZLIB_BYTE_PTR(uncomp_buf);
+                matvar->internal->z->avail_in = 16;
+                do {
+                    matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                    matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                    err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                    byteswritten += fwrite(comp_buf,1,
                         buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+                } while ( matvar->internal->z->avail_out == 0 );
                 for ( i = 0; i < nfields; i++ ) {
                     size_t len = strlen(matvar->internal->fieldnames[i]);
                     memset(padzero,'\0',fieldname_size);
                     memcpy(padzero,matvar->internal->fieldnames[i],len);
-                    matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-                    matvar->internal->z->next_in   = ZLIB_BYTE_PTR(padzero);
-                    matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-                    matvar->internal->z->avail_in  = fieldname_size;
-                    err = deflate(matvar->internal->z,Z_NO_FLUSH);
-                    byteswritten += fwrite(comp_buf,1,
+                    matvar->internal->z->next_in  = ZLIB_BYTE_PTR(padzero);
+                    matvar->internal->z->avail_in = fieldname_size;
+                    do {
+                        matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
+                        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                        err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                        byteswritten += fwrite(comp_buf,1,
                             buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,
                             mat->fp);
+                    } while ( matvar->internal->z->avail_out == 0 );
                 }
                 free(padzero);
                 for ( i = 0; i < nmemb*nfields; i++ )
@@ -5682,22 +5754,15 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
             case MAT_C_OBJECT:
                 break;
         }
-        matvar->internal->z->avail_in  = 0;
-        matvar->internal->z->next_in   = NULL;
-        matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
-        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-
-        err = deflate(matvar->internal->z,Z_FINISH);
-        byteswritten += fwrite(comp_buf,1,
-            buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
-        while ( err != Z_STREAM_END && !matvar->internal->z->avail_out ) {
+        matvar->internal->z->next_in  = NULL;
+        matvar->internal->z->avail_in = 0;
+        do {
             matvar->internal->z->next_out  = ZLIB_BYTE_PTR(comp_buf);
             matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-
             err = deflate(matvar->internal->z,Z_FINISH);
             byteswritten += fwrite(comp_buf,1,
                 buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
-        }
+        } while ( err != Z_STREAM_END && matvar->internal->z->avail_out == 0 );
         /* End the compression and set to NULL so Mat_VarFree doesn't try
          * to free matvar->internal->z with inflateEnd
          */
@@ -5741,7 +5806,6 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
 
     /* FIXME: SEEK_END is not Guaranteed by the C standard */
     fseek(mat->fp,0,SEEK_END);         /* Always write at end of file */
-
 
     if ( matvar->compression == MAT_COMPRESSION_NONE ) {
         fwrite(&matrix_type,4,1,mat->fp);
@@ -5921,12 +5985,14 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
 
         uncomp_buf[0] = MAT_T_MATRIX;
         uncomp_buf[1] = 448;
-        matvar->internal->z->next_out  = comp_buf;
-        matvar->internal->z->next_in   = uncomp_buf;
-        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-        matvar->internal->z->avail_in  = 8;
-        err = deflate(matvar->internal->z,Z_SYNC_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+        matvar->internal->z->next_in  = uncomp_buf;
+        matvar->internal->z->avail_in = 8;
+        do {
+            matvar->internal->z->next_out  = comp_buf;
+            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+            err = deflate(matvar->internal->z,Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+        } while ( matvar->internal->z->avail_out == 0 );
         uncomp_buf[0] = array_flags_type;
         uncomp_buf[1] = array_flags_size;
         uncomp_buf[2] = array_flags;
@@ -5944,12 +6010,16 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
         if ( matvar->rank % 2 != 0 )
             uncomp_buf[6+i] = pad4;
 
-        matvar->internal->z->next_out  = comp_buf;
-        matvar->internal->z->next_in   = uncomp_buf;
-        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-        matvar->internal->z->avail_in  = (6+i)*sizeof(*uncomp_buf);
-        err = deflate(matvar->internal->z,Z_NO_FLUSH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+        matvar->internal->z->next_in  = uncomp_buf;
+        matvar->internal->z->avail_in = (6+i)*sizeof(*uncomp_buf);
+        do {
+            matvar->internal->z->next_out  = comp_buf;
+            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+            err = deflate(matvar->internal->z,Z_NO_FLUSH);
+            byteswritten += fwrite(comp_buf,1,
+                buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,
+                mat->fp);
+        } while ( matvar->internal->z->avail_out == 0 );
         /* Name of variable */
         if ( strlen(matvar->name) <= 4 ) {
 #if 0
@@ -5959,12 +6029,16 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
             uncomp_buf[0] = (array_name_type << 16) | array_name_len;
             memcpy(uncomp_buf+1,matvar->name,array_name_len);
 
-            matvar->internal->z->next_out  = comp_buf;
-            matvar->internal->z->next_in   = uncomp_buf;
-            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-            matvar->internal->z->avail_in  = 8;
-            err = deflate(matvar->internal->z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+            matvar->internal->z->next_in  = uncomp_buf;
+            matvar->internal->z->avail_in = 8;
+            do {
+                matvar->internal->z->next_out  = comp_buf;
+                matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,
+                    buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,
+                    mat->fp);
+            } while ( matvar->internal->z->avail_out == 0 );
         } else {
 #endif
             mat_int32_t array_name_len = (mat_int32_t)strlen(matvar->name);
@@ -5975,12 +6049,15 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
             memcpy(uncomp_buf+2,matvar->name,array_name_len);
             if ( array_name_len % 8 )
                 array_name_len += array_name_len % 8;
-            matvar->internal->z->next_out  = comp_buf;
             matvar->internal->z->next_in   = uncomp_buf;
-            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
             matvar->internal->z->avail_in  = 8+array_name_len;
-            err = deflate(matvar->internal->z,Z_FULL_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+            do {
+                matvar->internal->z->next_out  = comp_buf;
+                matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+                err = deflate(matvar->internal->z,Z_NO_FLUSH);
+                byteswritten += fwrite(comp_buf,1,
+                    buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+            } while ( matvar->internal->z->avail_out == 0 );
         }
         matvar->internal->datapos = ftell(mat->fp);
         deflateCopy(&z_save,matvar->internal->z);
@@ -6007,16 +6084,19 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
 #endif
                 break;
         }
-        matvar->internal->z->next_out  = comp_buf;
-        matvar->internal->z->next_in   = NULL;
-        matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
-        matvar->internal->z->avail_in  = 0;
-
-        err = deflate(matvar->internal->z,Z_FINISH);
-        byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
-                if ( byteswritten % 8 )
-                    for ( i = byteswritten % 8; i < 8; i++ )
-                        fwrite(&pad1,1,1,mat->fp);
+        matvar->internal->z->next_in  = NULL;
+        matvar->internal->z->avail_in = 0;
+        do {
+            matvar->internal->z->next_out  = comp_buf;
+            matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
+            err = deflate(matvar->internal->z,Z_FINISH);
+            byteswritten += fwrite(comp_buf,1,
+                buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,
+                mat->fp);
+        } while ( err != Z_STREAM_END && matvar->internal->z->avail_out == 0 );
+        if ( byteswritten % 8 )
+            for ( i = byteswritten % 8; i < 8; i++ )
+                fwrite(&pad1,1,1,mat->fp);
         fprintf(stderr,"deflate Z_FINISH: err = %d,byteswritten = %u\n",err,byteswritten);
 
         err = deflateEnd(matvar->internal->z);
@@ -6050,7 +6130,7 @@ matvar_t *
 Mat_VarReadNextInfo5( mat_t *mat )
 {
     int err, data_type, nBytes, i;
-    long  fpos;
+    long fpos;
     matvar_t *matvar = NULL;
     mat_uint32_t array_flags;
 

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -5991,7 +5991,9 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
             matvar->internal->z->next_out  = comp_buf;
             matvar->internal->z->avail_out = buf_size*sizeof(*comp_buf);
             err = deflate(matvar->internal->z,Z_NO_FLUSH);
-            byteswritten += fwrite(comp_buf,1,buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,mat->fp);
+            byteswritten += fwrite(comp_buf,1,
+                buf_size*sizeof(*comp_buf)-matvar->internal->z->avail_out,
+                mat->fp);
         } while ( matvar->internal->z->avail_out == 0 );
         uncomp_buf[0] = array_flags_type;
         uncomp_buf[1] = array_flags_size;

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -5732,7 +5732,7 @@ WriteInfo5(mat_t *mat, matvar_t *matvar)
     mat_int8_t  pad1 = 0;
     int      array_flags_type = MAT_T_UINT32, dims_array_type = MAT_T_INT32;
     int      array_flags_size = 8, pad4 = 0, matrix_type = MAT_T_MATRIX;
-    int      nBytes, i, nmemb = 1,nzmax;
+    int      nBytes, i, nmemb = 1,nzmax = 0;
     long     start = 0, end = 0;
 
     /* FIXME: SEEK_END is not Guaranteed by the C standard */

--- a/src/mat5.c
+++ b/src/mat5.c
@@ -5443,6 +5443,10 @@ Mat_VarWrite5(mat_t *mat,matvar_t *matvar,int compress)
         int buf_size = 512, err;
         size_t byteswritten = 0;
 
+        if (matvar->internal->z != NULL) {
+            inflateEnd(matvar->internal->z);
+            free(matvar->internal->z);
+        }
         matvar->internal->z         = calloc(1,sizeof(*matvar->internal->z));
         matvar->internal->z->zalloc = Z_NULL;
         matvar->internal->z->zfree  = Z_NULL;

--- a/visual_studio/libmatio/libmatio.vcxproj
+++ b/visual_studio/libmatio/libmatio.vcxproj
@@ -76,7 +76,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(HDF5_DIR)/include;$(SolutionDir);$(SolutionDir)/../src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;H5_BUILT_AS_DYNAMIC_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling />
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -101,7 +101,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(HDF5_DIR)/include;$(SolutionDir);$(SolutionDir)/../src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;H5_BUILT_AS_DYNAMIC_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling />
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -122,7 +122,7 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(HDF5_DIR)/include;$(SolutionDir);$(SolutionDir)/../src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;H5_BUILT_AS_DYNAMIC_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling />
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -147,7 +147,7 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(HDF5_DIR)/include;$(SolutionDir);$(SolutionDir)/../src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REPLACE_GETOPT;MAT73=1;HAVE_HDF5=1;HAVE_ZLIB=1;H5_BUILT_AS_DYNAMIC_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling />
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/visual_studio/matioConfig.h
+++ b/visual_studio/matioConfig.h
@@ -61,7 +61,11 @@
 #define HAVE_MEMORY_H 1
 
 /* Have snprintf */
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#define HAVE_SNPRINTF 1
+#else
 #undef HAVE_SNPRINTF
+#endif
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -92,7 +96,14 @@
 #endif
 
 /* Have vsnprintf */
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#define HAVE_VSNPRINTF 1
+#if !defined(HAVE_C99_VSNPRINTF)
+#define HAVE_C99_VSNPRINTF 1
+#endif
+#else
 #undef HAVE_VSNPRINTF
+#endif
 
 /* Have va_copy */
 #undef HAVE___VA_COPY

--- a/visual_studio/matioConfig.h
+++ b/visual_studio/matioConfig.h
@@ -85,7 +85,11 @@
 #undef HAVE_VASPRINTF
 
 /* Have va_copy */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
+#define HAVE_VA_COPY 1
+#else
 #undef HAVE_VA_COPY
+#endif
 
 /* Have vsnprintf */
 #undef HAVE_VSNPRINTF


### PR DESCRIPTION
Please test if b0e6465 solves your problem in https://sourceforge.net/p/matio/bugs/28/. I solved it differently than the mentioned workaround with `Z_PARTIAL_FLUSH`. Instead this fix calls `deflate` (with `Z_NO_FLUSH`) always in a loop.

Thanks for your collaboration.